### PR TITLE
Add a file-extention blacklist to prevent removing trail blanks

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -247,5 +247,6 @@ autocmd FileType fstab,systemd set noexpandtab
 autocmd FileType gitconfig,sh,toml,vim set noexpandtab
 au BufRead,BufNewFile MAINTAINERS set ft=toml
 
-" auto strip whitespace
-autocmd BufWritePre * StripWhitespace
+" auto strip whitespace except for file with extention blacklisted
+let blacklist = ['markdown', 'md']
+autocmd BufWritePre * if index(blacklist, &ft) < 0 | StripWhitespace


### PR DESCRIPTION
In some files like Markdown is important to have trailing blanks otherwise you won't be able to split text on multiple lines.
This add a blacklist for these files: *md , *mardkdown 